### PR TITLE
Fix workflows to handle case when citations.md doesn't exist

### DIFF
--- a/.github/workflows/pubmed-citations.yml
+++ b/.github/workflows/pubmed-citations.yml
@@ -100,7 +100,11 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add data.json metadata/ citations.md
+          git add data.json metadata/
+          # Add citations.md if it exists
+          if [ -f citations.md ]; then
+            git add citations.md
+          fi
           if git diff --staged --quiet; then
             echo "No changes to commit"
             echo "changes_detected=false" >> $GITHUB_OUTPUT
@@ -127,8 +131,8 @@ jobs:
             
             Changes include:
             - Updated PubMed citation data in metadata directory
-            - Updated citations.md with latest citation information
             - Updated data.json with the latest PubMed information
+            - Updated citations.md if present
             
             Generated automatically by GitHub Actions workflow.
           branch: ${{ steps.commit.outputs.branch_name }}

--- a/.github/workflows/update-repos.yml
+++ b/.github/workflows/update-repos.yml
@@ -218,7 +218,11 @@ jobs:
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
-          git add data.json metadata/ reports/ citations.md
+          git add data.json metadata/ reports/
+          # Add citations.md if it exists
+          if [ -f citations.md ]; then
+            git add citations.md
+          fi
           if git diff --staged --quiet; then
             echo "No changes to commit"
             echo "changes_detected=false" >> $GITHUB_OUTPUT


### PR DESCRIPTION
I've fixed the issue with the workflows trying to add a citations.md file that might not exist. Here's what I
  changed:

  1. In both workflows, replaced direct inclusion of citations.md in the git add command with conditional checks:
  # Add citations.md if it exists
  if [ -f citations.md ]; then
    git add citations.md
  fi
  2. Updated the PR description in the PubMed workflow to clarify that citations.md is updated only if it exists