### PR TITLE
Add automated PR creation to Data Quality Metrics workflow

### DIFF
--- a/.github/workflows/data-quality.yml
+++ b/.github/workflows/data-quality.yml
@@ -5,11 +5,19 @@ on:
     - cron: "0 5 * * 1"  # Every Monday at 5am UTC (after workflow coordination)
   workflow_dispatch:
 
+# Permissions needed for creating and managing PRs
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   collect-data-metrics:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # Fetch all history for proper branch creation
+          fetch-depth: 0
       
       - name: Set up Python
         uses: actions/setup-python@v5
@@ -111,13 +119,64 @@ jobs:
             reports/data_quality_trends.png
             reports/data_quality_history.json
       
-      - name: Commit updated reports
+      - name: Prepare changes
+        id: prepare
         run: |
           git config --local user.email "action@github.com"
           git config --local user.name "GitHub Action"
+          
+          # Add all reports
           git add reports/metrics_report.json reports/data_quality_report.md reports/data_quality_history.json
           if [ -f "reports/data_quality_trends.png" ]; then
             git add reports/data_quality_trends.png
           fi
-          git diff --staged --quiet || git commit -m "Update data quality metrics"
-          git push
+          
+          # Check if there are changes to commit
+          if git diff --staged --quiet; then
+            echo "No changes to commit"
+            echo "changes_detected=false" >> $GITHUB_OUTPUT
+          else
+            # Create a unique branch name with timestamp
+            BRANCH_NAME="data-quality-metrics-$(date +%Y%m%d-%H%M%S)"
+            echo "changes_detected=true" >> $GITHUB_OUTPUT
+            echo "branch_name=$BRANCH_NAME" >> $GITHUB_OUTPUT
+          fi
+      
+      - name: Create Pull Request
+        if: steps.prepare.outputs.changes_detected == 'true'
+        id: create-pr
+        uses: peter-evans/create-pull-request@v5
+        with:
+          # Use PAT_TOKEN if available, otherwise fall back to GITHUB_TOKEN
+          token: ${{ secrets.PAT_TOKEN || secrets.GITHUB_TOKEN }}
+          commit-message: Update data quality metrics
+          title: Update data quality metrics
+          body: |
+            ## Automated PR with data quality metrics
+            
+            This PR updates the data quality metrics based on the latest analysis run.
+            
+            Changes include:
+            - Updated data quality metrics in `reports/metrics_report.json`
+            - Updated data quality report in `reports/data_quality_report.md`
+            - Updated data quality history in `reports/data_quality_history.json`
+            - Updated data quality trends visualization (if available)
+            
+            Generated automatically by GitHub Actions workflow.
+          branch: ${{ steps.prepare.outputs.branch_name }}
+          base: main
+          delete-branch: false
+      
+      - name: PR Creation Result
+        if: steps.prepare.outputs.changes_detected == 'true'
+        run: |
+          if [[ -n "${{ steps.create-pr.outputs.pull-request-url }}" ]]; then
+            echo "::notice::PR created successfully: ${{ steps.create-pr.outputs.pull-request-url }}"
+          else
+            echo "::warning::PR creation failed. You need to configure one of the following:"
+            echo "::warning::1. Add a Personal Access Token (PAT) with 'repo' scope as a repository secret named 'PAT_TOKEN'"
+            echo "::warning::2. Enable 'Allow GitHub Actions to create and approve pull requests' in repository Settings > Actions > General"
+            
+            # Provide manual PR creation URL as fallback
+            echo "::notice::For now, you can create a PR manually at: https://github.com/$GITHUB_REPOSITORY/pull/new/${{ steps.prepare.outputs.branch_name }}"
+          fi


### PR DESCRIPTION
This commit updates the Data Quality Metrics workflow to use an automated PR creation process instead of direct commits to the main branch, which were causing repository rule violations due to branch protection rules.

Key changes:
- Added required permissions (contents: write, pull-requests: write)
- Added fetch-depth: 0 to actions/checkout to ensure proper branch creation
- Replaced the direct commit and push with a prepare step to detect changes
- Added automated PR creation using peter-evans/create-pull-request action
- Added fallback logic for when PR creation fails