### PR TITLE
fixed perc. code covereage calculation

### DIFF
--- a/index.html
+++ b/index.html
@@ -1435,11 +1435,18 @@
                     let languagesHtml = 'No language information available';
                     if (tool.languages && Object.keys(tool.languages).length > 0) {
                         const languageEntries = Object.entries(tool.languages);
-                        languageEntries.sort((a, b) => b[1] - a[1]); // Sort by percentage (descending)
+                        languageEntries.sort((a, b) => b[1] - a[1]); // Sort by bytes (descending)
+                        
+                        // Calculate total bytes to determine percentages
+                        const totalBytes = languageEntries.reduce((sum, [_, bytes]) => sum + bytes, 0);
                         
                         languagesHtml = `
                             <div class="language-bars">
-                                ${languageEntries.map(([lang, percentage]) => `
+                                ${languageEntries.map(([lang, bytes]) => {
+                                    // Calculate actual percentage
+                                    const percentage = totalBytes > 0 ? ((bytes / totalBytes) * 100).toFixed(1) : 0;
+                                    
+                                    return `
                                     <div class="mb-1">
                                         <div class="d-flex justify-content-between mb-1">
                                             <span>${lang}</span>
@@ -1449,7 +1456,8 @@
                                             <div class="progress-bar" style="width: ${percentage}%; background-color: var(--accent-color);"></div>
                                         </div>
                                     </div>
-                                `).join('')}
+                                    `;
+                                }).join('')}
                             </div>
                         `;
                     }


### PR DESCRIPTION
The GitHub API returns language data as byte counts (not percentages), but the dashboard was displaying
  these raw numbers as percentages