### PR TITLE
Fix YAML syntax in citation-validation workflow

### DIFF
--- a/.github/workflows/citation-validation.yml
+++ b/.github/workflows/citation-validation.yml
@@ -284,21 +284,27 @@ jobs:
           FIXED_DOIS=${{ steps.check_issues.outputs.fixed_dois }}
           if [[ $FIXED_DOIS -gt 0 ]]; then
             TITLE="Update citation validation metrics and fix $FIXED_DOIS DOI format issues"
-            BODY="## Automated PR with citation validation results
+            BODY=$(cat <<EOF
+## Automated PR with citation validation results
 
 This PR includes:
 - Updated citation validation metrics in \`reports/citations/citation_validation_metrics.json\`
 - Automatically fixed $FIXED_DOIS DOI formatting issues in metadata files
 
-Generated automatically by the Citation Data Validation workflow."
+Generated automatically by the Citation Data Validation workflow.
+EOF
+)
           else
             TITLE="Update citation validation metrics"
-            BODY="## Automated PR with citation validation results
+            BODY=$(cat <<EOF
+## Automated PR with citation validation results
 
 This PR includes:
 - Updated citation validation metrics in \`reports/citations/citation_validation_metrics.json\`
 
-Generated automatically by the Citation Data Validation workflow."
+Generated automatically by the Citation Data Validation workflow.
+EOF
+)
           fi
           
           gh pr create --base main --head ${{ steps.prepare.outputs.branch_name }} --title "$TITLE" --body "$BODY" || true

--- a/.github/workflows/citation-validation.yml
+++ b/.github/workflows/citation-validation.yml
@@ -284,23 +284,25 @@ jobs:
           FIXED_DOIS=${{ steps.check_issues.outputs.fixed_dois }}
           if [[ $FIXED_DOIS -gt 0 ]]; then
             TITLE="Update citation validation metrics and fix $FIXED_DOIS DOI format issues"
-            BODY=$(cat <<EOF
+            # Use sed to replace the placeholder with the actual value
+            BODY=$(cat <<'EOF'
 ## Automated PR with citation validation results
 
 This PR includes:
-- Updated citation validation metrics in \`reports/citations/citation_validation_metrics.json\`
-- Automatically fixed $FIXED_DOIS DOI formatting issues in metadata files
+- Updated citation validation metrics in `reports/citations/citation_validation_metrics.json`
+- Automatically fixed __FIXED_DOIS__ DOI formatting issues in metadata files
 
 Generated automatically by the Citation Data Validation workflow.
 EOF
 )
+            BODY=$(echo "$BODY" | sed "s/__FIXED_DOIS__/$FIXED_DOIS/g")
           else
             TITLE="Update citation validation metrics"
-            BODY=$(cat <<EOF
+            BODY=$(cat <<'EOF'
 ## Automated PR with citation validation results
 
 This PR includes:
-- Updated citation validation metrics in \`reports/citations/citation_validation_metrics.json\`
+- Updated citation validation metrics in `reports/citations/citation_validation_metrics.json`
 
 Generated automatically by the Citation Data Validation workflow.
 EOF


### PR DESCRIPTION
## Fix for the Citation Data Validation workflow

This PR fixes the YAML syntax issue in the citation-validation.yml workflow file that was preventing it from appearing in the GitHub Actions UI.

### Changes:

1. Fixed multiline string syntax in the PR creation step by using proper bash heredoc format
2. Added proper quoting to heredocs with the single-quote syntax () to prevent variable expansion within the heredoc
3. Used a placeholder and sed replacement for incorporating variables into the heredoc content

These changes should resolve the YAML syntax errors and allow the workflow to be properly registered with GitHub Actions, making it visible in the UI and allowing manual triggering.

Fixes the workflow file error reported in PR #81.