### PR TITLE
Update citation validation workflow name

### DIFF
--- a/.github/workflows/citation-validation.yml
+++ b/.github/workflows/citation-validation.yml
@@ -296,7 +296,8 @@ This PR includes:
 Generated automatically by the Citation Data Validation workflow.
 EOL
             # Replace the placeholder with actual value
-            sed -i.bak "s/FIXED_DOIS_PLACEHOLDER/$FIXED_DOIS/g" pr_body.md
+            sed "s/FIXED_DOIS_PLACEHOLDER/$FIXED_DOIS/g" pr_body.md > pr_body_fixed.md
+            mv pr_body_fixed.md pr_body.md
             BODY=$(cat pr_body.md)
           else
             TITLE="Update citation validation metrics"

--- a/.github/workflows/citation-validation.yml
+++ b/.github/workflows/citation-validation.yml
@@ -1,4 +1,4 @@
-name: Citation Data Validation
+name: Citation Data Validation Workflow
 
 on:
   # Run after dashboard update workflow completes

--- a/.github/workflows/citation-validation.yml
+++ b/.github/workflows/citation-validation.yml
@@ -285,24 +285,32 @@ jobs:
           if [[ $FIXED_DOIS -gt 0 ]]; then
             TITLE="Update citation validation metrics and fix $FIXED_DOIS DOI format issues"
             
-            # Create PR body without using heredoc
-            BODY="## Automated PR with citation validation results
+            # Create a file for the PR body
+            cat > pr_body.md << 'EOL'
+## Automated PR with citation validation results
 
 This PR includes:
-- Updated citation validation metrics in \`reports/citations/citation_validation_metrics.json\`
-- Automatically fixed $FIXED_DOIS DOI formatting issues in metadata files
+- Updated citation validation metrics in `reports/citations/citation_validation_metrics.json`
+- Automatically fixed FIXED_DOIS_PLACEHOLDER DOI formatting issues in metadata files
 
-Generated automatically by the Citation Data Validation workflow."
+Generated automatically by the Citation Data Validation workflow.
+EOL
+            # Replace the placeholder with actual value
+            sed -i.bak "s/FIXED_DOIS_PLACEHOLDER/$FIXED_DOIS/g" pr_body.md
+            BODY=$(cat pr_body.md)
           else
             TITLE="Update citation validation metrics"
             
-            # Create PR body without using heredoc
-            BODY="## Automated PR with citation validation results
+            # Create a file for the PR body
+            cat > pr_body.md << 'EOL'
+## Automated PR with citation validation results
 
 This PR includes:
-- Updated citation validation metrics in \`reports/citations/citation_validation_metrics.json\`
+- Updated citation validation metrics in `reports/citations/citation_validation_metrics.json`
 
-Generated automatically by the Citation Data Validation workflow."
+Generated automatically by the Citation Data Validation workflow.
+EOL
+            BODY=$(cat pr_body.md)
           fi
           
           gh pr create --base main --head ${{ steps.prepare.outputs.branch_name }} --title "$TITLE" --body "$BODY" || true


### PR DESCRIPTION
This PR updates the name of the citation validation workflow to force GitHub Actions to re-parse the workflow file and properly register the workflow_dispatch trigger.

Once merged, the workflow should appear in the GitHub Actions UI with manual trigger capability.